### PR TITLE
Add sitemap.xml and robots.txt for crawl indexing

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -27,6 +27,16 @@
               {
                 "glob": "**/*",
                 "input": "public"
+              },
+              {
+                "glob": "sitemap.xml",
+                "input": "src",
+                "output": "/"
+              },
+              {
+                "glob": "robots.txt",
+                "input": "src",
+                "output": "/"
               }
             ],
             "styles": ["src/styles.scss"],

--- a/src/robots.txt
+++ b/src/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://brianrogstad.com/sitemap.xml

--- a/src/sitemap.xml
+++ b/src/sitemap.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://brianrogstad.com/</loc></url>
+  <url><loc>https://brianrogstad.com/about</loc></url>
+  <url><loc>https://brianrogstad.com/projects/admin</loc></url>
+  <url><loc>https://brianrogstad.com/projects/bpm</loc></url>
+  <url><loc>https://brianrogstad.com/projects/contact</loc></url>
+  <url><loc>https://brianrogstad.com/projects/earth</loc></url>
+  <url><loc>https://brianrogstad.com/projects/emails</loc></url>
+  <url><loc>https://brianrogstad.com/projects/legal</loc></url>
+  <url><loc>https://brianrogstad.com/projects/life</loc></url>
+  <url><loc>https://brianrogstad.com/projects/logo</loc></url>
+  <url><loc>https://brianrogstad.com/projects/mobile</loc></url>
+  <url><loc>https://brianrogstad.com/projects/model</loc></url>
+  <url><loc>https://brianrogstad.com/projects/proto</loc></url>
+  <url><loc>https://brianrogstad.com/projects/reference</loc></url>
+  <url><loc>https://brianrogstad.com/projects/reflow</loc></url>
+  <url><loc>https://brianrogstad.com/projects/rough</loc></url>
+  <url><loc>https://brianrogstad.com/projects/tremor-maps</loc></url>
+  <url><loc>https://brianrogstad.com/projects/tremor-system</loc></url>
+  <url><loc>https://brianrogstad.com/projects/usb-maps</loc></url>
+  <url><loc>https://brianrogstad.com/projects/usb-system</loc></url>
+  <url><loc>https://brianrogstad.com/projects/usb-wireframes</loc></url>
+  <url><loc>https://brianrogstad.com/projects/utility</loc></url>
+</urlset>


### PR DESCRIPTION
## Summary
- added  with all public routes (home, about, and 20 project detail paths)
- added  with a sitemap reference
- updated  build assets so both files are copied to the build output root

Closes UNW-190

Generated by Task Runner cron via OpenClaw.