### PR TITLE
Fix /about deep-link 404 on static hosting

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
+    "postbuild": "node scripts/generate-github-pages-routes.mjs",
     "watch": "ng build --watch --configuration development",
     "test": "ng test --watch=false --browsers=ChromeHeadless",
     "test:watch": "ng test",

--- a/scripts/generate-github-pages-routes.mjs
+++ b/scripts/generate-github-pages-routes.mjs
@@ -1,0 +1,21 @@
+import { cp, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const browserDistDir = path.resolve(__dirname, '..', 'dist', 'portfolio-site', 'browser');
+const indexHtmlPath = path.join(browserDistDir, 'index.html');
+const spaFallbackPath = path.join(browserDistDir, '404.html');
+const staticRoutes = ['about'];
+
+await cp(indexHtmlPath, spaFallbackPath);
+
+for (const route of staticRoutes) {
+  const routeDir = path.join(browserDistDir, route);
+  await mkdir(routeDir, { recursive: true });
+  await cp(indexHtmlPath, path.join(routeDir, 'index.html'));
+}
+
+console.log(`Generated GitHub Pages route entry points for: ${staticRoutes.join(', ')}`);


### PR DESCRIPTION
## Summary
- add a postbuild step that generates static SPA entry points for direct-route requests
- create  and  from the built app shell
- preserve the existing Angular  route while fixing static-host deep-link handling for GitHub Pages-style hosting

Closes UNW-812

Generated by pest-control cron via OpenClaw.