### PR TITLE
refactor: remove unused CommonModule import from home

### DIFF
--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { CommonModule, NgTemplateOutlet } from '@angular/common';
+import { NgTemplateOutlet } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { ProjectsService } from '../../services/projects.service';
 import { SeoService } from '../../services/seo.service';
@@ -8,7 +8,7 @@ import { ToWebpPipe } from '../../pipes/to-webp.pipe';
 
 @Component({
   selector: 'app-home',
-  imports: [CommonModule, RouterLink, NgTemplateOutlet, ToWebpPipe],
+  imports: [RouterLink, NgTemplateOutlet, ToWebpPipe],
   templateUrl: './home.component.html',
   styleUrl: './home.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
## What
HomeComponent imported `CommonModule` but the template only uses `@if`/`@for` (built-in control flow) and `*ngTemplateOutlet` (which is separately imported as `NgTemplateOutlet`). Dropping the unused import keeps the component's `imports` array honest and matches Angular 18's standalone, control-flow-first style.

## How
Removed `CommonModule` from both the named import in `@angular/common` and the component's `imports` array.

Generated by Code Review cron.