### PR TITLE
refactor: drop redundant Title inject in project-detail

### DIFF
--- a/src/app/pages/project-detail/project-detail.component.ts
+++ b/src/app/pages/project-detail/project-detail.component.ts
@@ -7,7 +7,6 @@ import {
 } from '@angular/core';
 
 import { ActivatedRoute, RouterLink } from '@angular/router';
-import { Title } from '@angular/platform-browser';
 import { ProjectsService } from '../../services/projects.service';
 import { SeoService } from '../../services/seo.service';
 import { ProjectDetail } from '../../models/project.model';
@@ -37,7 +36,6 @@ interface ProjectNeighbor {
 export class ProjectDetailComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private projectsService = inject(ProjectsService);
-  private titleService = inject(Title);
   private seo = inject(SeoService);
   private cdr = inject(ChangeDetectorRef);
 
@@ -63,7 +61,6 @@ export class ProjectDetailComponent implements OnInit {
           this.project = data;
           if (data) {
             const title = `${data.title} — Brian Rogstad`;
-            this.titleService.setTitle(title);
             const leadImage =
               data.media?.find((m) => m.type === 'image')?.src ?? data.images?.[0]?.src;
             this.seo.update({


### PR DESCRIPTION
## What
`ProjectDetailComponent` injected `Title` from `@angular/platform-browser` and called `titleService.setTitle(title)` directly, but the very next line called `this.seo.update({ title, ... })`. `SeoService.update()` already calls `Title.setTitle(config.title)` internally, so the manual call was a duplicate write. Removing it consolidates per-route title updates in `SeoService`, matching how `home` and `about` already work — they only inject `SeoService`, never `Title`.

## How
Dropped the `Title` import, the `private titleService = inject(Title)` field, and the redundant `this.titleService.setTitle(title)` call from `src/app/pages/project-detail/project-detail.component.ts`. The local `title` const is still used as the `title` field in the `seo.update({ ... })` call.

Generated by Code Review cron.