### PR TITLE
refactor: simplify to-webp pipe falsy guard

### DIFF
--- a/src/app/pipes/to-webp.pipe.ts
+++ b/src/app/pipes/to-webp.pipe.ts
@@ -19,9 +19,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class ToWebpPipe implements PipeTransform {
   transform(src: string | null | undefined): string {
-    if (!src) {
-      return src ?? '';
-    }
+    if (!src) return '';
     return src.replace(/\.(jpe?g|png)(\?.*)?$/i, '.webp$2');
   }
 }


### PR DESCRIPTION
## What
Inside the `if (!src)` branch of `ToWebpPipe.transform`, the only possible values for `src` are `null`, `undefined`, and `''` — so `src ?? ''` always evaluates to `''`. The nullish coalesce is dead defense and slightly misleading (it suggests `src` might still be a meaningful string here).

Replacing it with `return '';` collapses the three-line block to a single guard clause and removes the head-scratch.

## How
- `src/app/pipes/to-webp.pipe.ts`: collapsed the `if (!src) { return src ?? ''; }` block to `if (!src) return '';`. No behavior change — same return value for every input.

Build verified clean (`npm run build`).

Generated by Code Review cron.