### PR TITLE
refactor: mark home component sections field private

### DIFF
--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -17,7 +17,7 @@ export class HomeComponent implements OnInit {
   private projectsService = inject(ProjectsService);
   private seo = inject(SeoService);
 
-  sections: HomeCardSection[] = this.projectsService.getHomeCardSections();
+  private sections: HomeCardSection[] = this.projectsService.getHomeCardSections();
   lightSections: HomeCardSection[] = this.sections.filter((s) => s.tone !== 'dark');
   darkSections: HomeCardSection[] = this.sections.filter((s) => s.tone === 'dark');
 


### PR DESCRIPTION
## What
The `sections` field on `HomeComponent` was public but only used inside the class itself to derive `lightSections` and `darkSections`. The template only consumes the two derived fields, never `sections` directly. Marking it `private` documents the encapsulation and prevents accidental external coupling.

## How
Added `private` modifier to the `sections` field declaration in [home.component.ts](src/app/pages/home/home.component.ts).

Generated by Code Review cron.