### PR TITLE
refactor: flatten nested ternary in SeoService image resolution

### DIFF
--- a/src/app/services/seo.service.ts
+++ b/src/app/services/seo.service.ts
@@ -30,11 +30,15 @@ export class SeoService {
 
   update(config: SeoConfig): void {
     const url = this.origin + (config.path.startsWith('/') ? config.path : `/${config.path}`);
-    const image = config.image
-      ? config.image.startsWith('http')
-        ? config.image
-        : `${this.origin}${config.image.startsWith('/') ? '' : '/'}${config.image}`
-      : this.defaultImage;
+    let image: string;
+    if (!config.image) {
+      image = this.defaultImage;
+    } else if (config.image.startsWith('http')) {
+      image = config.image;
+    } else {
+      const separator = config.image.startsWith('/') ? '' : '/';
+      image = `${this.origin}${separator}${config.image}`;
+    }
     const type = config.type ?? 'website';
 
     this.titleService.setTitle(config.title);


### PR DESCRIPTION
## What
`SeoService.update()` resolved the OpenGraph image URL with a triple-nested ternary that interleaved three separate concerns: defaulting when no image is provided, passing absolute URLs through, and prefixing relative paths with the site origin. Flattening to `if`/`else if`/`else` makes each branch self-evident at a glance and removes the inner ternary inside a string template.

## How
Replaced the chained ternary with an `if/else if/else` block. The relative-path branch now extracts the leading-slash check into a `separator` const so the template literal stays linear. Behavior is identical: same defaults, same passthrough, same prefix logic. No public API change.

Generated by Code Review cron.