### PR TITLE
refactor: remove scaffolded AppComponent title field

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -16,12 +16,6 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have the 'portfolioSite' title`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('portfolioSite');
-  });
-
   it('should render the site name in the header', () => {
     // Note: AppComponent no longer owns an <h1>. Per UNW-192, h1s moved
     // into per-page components for accessibility. AppComponent's chrome

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -25,7 +25,6 @@ export interface NavItem {
 export class AppComponent {
   private platformId = inject<object>(PLATFORM_ID);
 
-  title = 'portfolioSite';
   mobileMenuOpen = false;
   openDropdownLabel: string | null = null;
   forceClosedDropdown: string | null = null;


### PR DESCRIPTION
## What
Drop the `title = 'portfolioSite'` field from `AppComponent` and the auto-generated spec that asserts it. The field is Angular CLI scaffolding never referenced in any template — it was pure dead code.

## How
- Remove the `title` property from `src/app/app.component.ts`
- Remove the `should have the 'portfolioSite' title` spec from `src/app/app.component.spec.ts`

Build verified before and after.

Generated by Code Review cron.